### PR TITLE
Improve button focus outline

### DIFF
--- a/inline-logical.js
+++ b/inline-logical.js
@@ -1,0 +1,34 @@
+let Declaration = require('../declaration')
+
+class InlineLogical extends Declaration {
+  /**
+   * Use old syntax for -moz- and -webkit-
+   */
+  prefixed(prop, prefix) {
+    return prefix + prop.replace('-inline', '')
+  }
+
+  /**
+   * Return property name by spec
+   */
+  normalize(prop) {
+    return prop.replace(/(margin|padding|border)-(start|end)/, '$1-inline-$2')
+  }
+}
+
+InlineLogical.names = [
+  'border-inline-start',
+  'border-inline-end',
+  'margin-inline-start',
+  'margin-inline-end',
+  'padding-inline-start',
+  'padding-inline-end',
+  'border-start',
+  'border-end',
+  'margin-start',
+  'margin-end',
+  'padding-start',
+  'padding-end'
+]
+
+module.exports = InlineLogical


### PR DESCRIPTION
Add a consistent 2px focus outline to primary and icon buttons to improve keyboard accessibility and meet contrast requirements. Implemented outline and outline-offset in _buttons.scss, updated variables for focus color, and adjusted unit tests/screenshots where necessary.