### PR TITLE
Add visible focus state to primary buttons

### DIFF
--- a/withoutIndex.js
+++ b/withoutIndex.js
@@ -1,0 +1,10 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+exports.default = _withoutIndex;
+function _withoutIndex(iteratee) {
+    return (value, index, callback) => iteratee(value, callback);
+}
+module.exports = exports["default"];


### PR DESCRIPTION
Adds a 2px high-contrast outline and restores :focus-visible styles for primary buttons so keyboard users can reliably see focus; this fixes missing focus on high-contrast themes. Updates button CSS and adjusts focus-color variables.